### PR TITLE
Add analytics flush & status endpoints

### DIFF
--- a/include/analytics_manager.h
+++ b/include/analytics_manager.h
@@ -78,6 +78,7 @@ public:
     void run(ReplicationState* raft_server);
     void init(Store* store, Store* analytics_store, uint32_t analytics_minute_rate_limit);
     Option<nlohmann::json> process_create_rule_request(nlohmann::json& payload, bool is_live_req);
+    Option<nlohmann::json> get_status();
     void stop();
     void dispose();
 };

--- a/include/core_api.h
+++ b/include/core_api.h
@@ -174,6 +174,8 @@ bool del_analytics_rules(const std::shared_ptr<http_req>& req, const std::shared
 bool post_write_analytics_to_db(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);
 
 bool get_analytics_events(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);
+bool post_analytics_flush(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);
+bool get_analytics_status(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);
 
 //plurals, nouns
 bool post_import_stemming_dictionary(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);

--- a/include/query_analytics.h
+++ b/include/query_analytics.h
@@ -151,5 +151,8 @@ public:
   std::unordered_map<std::string, std::vector<query_event_t>> get_query_log_events();
   query_rule_config_t get_query_rule(const std::string& name);
   std::vector<query_event_t> get_user_prefix_queries(const std::string& user_id, const std::string& collection, const std::string& event_name);
+  size_t get_popular_prefix_queries_size();
+  size_t get_nohits_prefix_queries_size();
+  size_t get_log_prefix_queries_size();
   void dispose();
 };

--- a/src/analytics_manager.cpp
+++ b/src/analytics_manager.cpp
@@ -731,6 +731,41 @@ bool AnalyticsManager::write_to_db(const nlohmann::json& payload) {
     return true;
 }
 
+Option<nlohmann::json> AnalyticsManager::get_status() {
+    std::shared_lock lk(mutex);
+    nlohmann::json status;
+
+    status["popular_user_collection_prefix_queries"] = query_analytics.get_popular_prefix_queries_size();
+    status["nohits_user_collection_prefix_queries"] = query_analytics.get_nohits_prefix_queries_size();
+    status["log_user_collection_prefix_queries"] = query_analytics.get_log_prefix_queries_size();
+
+    size_t q_log = 0;
+    for (const auto& kv : query_analytics.get_query_log_events()) {
+        q_log += kv.second.size();
+    }
+    status["query_log_events"] = q_log;
+
+    size_t q_counter = 0;
+    for (const auto& kv : query_analytics.get_query_counter_events()) {
+        q_counter += kv.second.query_counts.size();
+    }
+    status["query_counter_events"] = q_counter;
+
+    size_t d_log = 0;
+    for (const auto& kv : doc_analytics.get_doc_log_events()) {
+        d_log += kv.second.size();
+    }
+    status["doc_log_events"] = d_log;
+
+    size_t d_counter = 0;
+    for (const auto& kv : doc_analytics.get_doc_counter_events()) {
+        d_counter += kv.second.docid_counts.size();
+    }
+    status["doc_counter_events"] = d_counter;
+
+    return Option<nlohmann::json>(status);
+}
+
 void AnalyticsManager::run(ReplicationState* raft_server) {
     uint64_t prev_persistence_s = std::chrono::duration_cast<std::chrono::seconds>(
                                     std::chrono::system_clock::now().time_since_epoch()).count();

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -3908,3 +3908,23 @@ bool get_analytics_events(const std::shared_ptr<http_req>& req, const std::share
     res->set_200(get_events_op.get().dump());
     return true;
 }
+
+bool post_analytics_flush(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {
+    auto raft_server = server->get_replication_state();
+    uint64_t now_ts_seconds = std::chrono::duration_cast<std::chrono::seconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+    AnalyticsManager::get_instance().persist_analytics_db_events(raft_server, now_ts_seconds);
+    AnalyticsManager::get_instance().persist_db_events(raft_server, now_ts_seconds);
+    res->set_200(R"({"ok": true})");
+    return true;
+}
+
+bool get_analytics_status(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {
+    auto status_op = AnalyticsManager::get_instance().get_status();
+    if(!status_op.ok()) {
+        res->set(status_op.code(), status_op.error());
+        return false;
+    }
+    res->set_200(status_op.get().dump());
+    return true;
+}

--- a/src/main/typesense_server.cpp
+++ b/src/main/typesense_server.cpp
@@ -84,6 +84,8 @@ void master_server_routes() {
     server->post("/analytics/events", post_create_event);
     server->post("/analytics/aggregate_events", post_write_analytics_to_db);
     server->get("/analytics/events", get_analytics_events);
+    server->post("/analytics/flush", post_analytics_flush);
+    server->get("/analytics/status", get_analytics_status);
 
     // for plurals, nouns
     server->post("/stemming/dictionaries/import", post_import_stemming_dictionary, true, true);

--- a/src/query_analytics.cpp
+++ b/src/query_analytics.cpp
@@ -477,6 +477,42 @@ query_rule_config_t QueryAnalytics::get_query_rule(const std::string& name) {
   return query_rules.find(name)->second;
 }
 
+size_t QueryAnalytics::get_popular_prefix_queries_size() {
+  std::shared_lock lock(mutex);
+  std::shared_lock user_lock(user_compaction_mutex);
+  size_t count = 0;
+  for (const auto& user_map : popular_user_collection_prefix_queries) {
+    for (const auto& coll_vec : user_map.second) {
+      count += coll_vec.second.size();
+    }
+  }
+  return count;
+}
+
+size_t QueryAnalytics::get_nohits_prefix_queries_size() {
+  std::shared_lock lock(mutex);
+  std::shared_lock user_lock(user_compaction_mutex);
+  size_t count = 0;
+  for (const auto& user_map : nohits_user_collection_prefix_queries) {
+    for (const auto& coll_vec : user_map.second) {
+      count += coll_vec.second.size();
+    }
+  }
+  return count;
+}
+
+size_t QueryAnalytics::get_log_prefix_queries_size() {
+  std::shared_lock lock(mutex);
+  std::shared_lock user_lock(user_compaction_mutex);
+  size_t count = 0;
+  for (const auto& user_map : log_user_collection_prefix_queries) {
+    for (const auto& coll_vec : user_map.second) {
+      count += coll_vec.second.size();
+    }
+  }
+  return count;
+}
+
 void QueryAnalytics::remove_all_rules() {
   std::unique_lock lock(mutex);
   query_rules.clear();


### PR DESCRIPTION
## Summary
- implement manual analytics flush endpoint
- add analytics status endpoint with counters
- expose pending query prefix queue sizes

## Testing
- `make test` *(no output)*
- `npm test` *(failed: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b3cd66bb8832d8ee09e4e376aec76